### PR TITLE
解决本地代理问题和用量为0问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,5 +117,7 @@
     "typescript": "^4.9.4",
     "@vscode/test-electron": "^2.2.3"
   },
-  "dependencies": {}
+  "dependencies": {
+    "https-proxy-agent": "^7.0.2"
+  }
 }


### PR DESCRIPTION
  **问题描述**
  - API 请求被本地代理拦截，导致返回数据为空或请求失败
  - 用量数据返回 null 值时导致计算错误

  **修复内容**
  - 添加 `agent: false` 禁用系统代理，确保 API 直连
  - 修复数据处理中的 null/undefined 值验证
  - 优化峰值计算和趋势图生成的数据过滤

  **测试结果**
  - API 请求正常返回数据
  - 配额和用量显示正确